### PR TITLE
buffer initialization (PHP)

### DIFF
--- a/templo/Loader.hx
+++ b/templo/Loader.hx
@@ -268,6 +268,7 @@ class Loader {
 	var b : Array<String>;
 	var content : String;
 	function bufferReset() {
+        buf = '';
 		b = [];
 		content = null;
 	}


### PR DESCRIPTION
If the buf var is not initialized, then "null" is displayed on top of each page using templo